### PR TITLE
fixes bugs

### DIFF
--- a/infrastructure/database/main.tf
+++ b/infrastructure/database/main.tf
@@ -1,10 +1,12 @@
 provider "aws" {
   region = "eu-west-2"
-  tags   = {
-    Environment = "DOI"
-    Owner       = "DiSSCo"
-    Project     = "DiSSCo DOI"
-    Terraform   = "True"
+  default_tags {
+    tags = {
+      Environment = "DOI"
+      Owner       = "DiSSCo"
+      Project     = "DiSSCo DOI"
+      Terraform   = "True"
+    }
   }
 }
 
@@ -12,8 +14,8 @@ data "terraform_remote_state" "vpc-state" {
   backend = "s3"
 
   config = {
-    bucket = "dissco-terraform-state-backend"
-    key    = "acceptance/vpc/terraform.tfstate"
+    bucket = "doi-terraform-state-backend"
+    key    = "doi/vpc/terraform.tfstate"
     region = "eu-west-2"
   }
 }
@@ -26,7 +28,7 @@ resource "aws_db_instance" "default" {
   engine_version         = "15.2"
   instance_class         = "db.m6g.large"
   publicly_accessible    = true
-  db_subnet_group_name   = data.terraform_remote_state.vpc-state.outputs.doi_server_subnets
+  db_subnet_group_name   = data.terraform_remote_state.vpc-state.outputs.doi_database_subnets
   vpc_security_group_ids = [
     data.terraform_remote_state.vpc-state.outputs.doi_database_security_group
   ]

--- a/infrastructure/database/outputs.tf
+++ b/infrastructure/database/outputs.tf
@@ -1,9 +1,0 @@
-output "address" {
-  value       = aws_db_instance.default.address
-  description = "Connect to the database at this endpoint"
-}
-
-output "port" {
-  value       = aws_db_instance.default.port
-  description = "The port the database is listening on"
-}

--- a/infrastructure/ec2/main.tf
+++ b/infrastructure/ec2/main.tf
@@ -12,15 +12,24 @@ provider "aws" {
 
 resource "aws_eip" "static_ip" {
   domain   = "vpc"
-  instance = aws_instance.doi_server
+  instance = aws_instance.doi_server.id
+}
+
+data "terraform_remote_state" "vpc-state" {
+  backend = "s3"
+
+  config = {
+    bucket = "doi-terraform-state-backend"
+    key    = "doi/vpc/terraform.tfstate"
+    region = "eu-west-2"
+  }
 }
 
 resource "aws_instance" "doi_server" {
-  source                      = "terraform-aws-modules/ec2-instance/aws"
   ami                         = "ami-0a244485e2e4ffd03"
   instance_type               = "t3.small"
   associate_public_ip_address = true
 
-  subnet_id = data.terraform_remote_state.vpc-state.doi_server_subnets
-  security_groups = [data.terraform_remote_state.vpc-state.doi_server_security_group]
+  subnet_id = data.terraform_remote_state.vpc-state.outputs.doi_server_subnets[0]
+  security_groups = [data.terraform_remote_state.vpc-state.outputs.doi_server_security_group]
 }

--- a/infrastructure/vpc/main.tf
+++ b/infrastructure/vpc/main.tf
@@ -65,14 +65,14 @@ resource "aws_security_group" "doi-server-sg" {
   ingress {
     from_port   = 22
     to_port     = 22
-    protocol    = "ssh"
+    protocol    = "tcp"
     description = "SSH access for Naturalis Eduroam"
     cidr_blocks = ["145.136.247.119/32"]
   }
   ingress {
     from_port   = 22
     to_port     = 22
-    protocol    = "ssh"
+    protocol    = "tcp"
     description = "SSH Access for Naturalis Network"
     cidr_blocks = ["145.136.247.125/32"]
   }

--- a/infrastructure/vpc/outputs.tf
+++ b/infrastructure/vpc/outputs.tf
@@ -1,3 +1,8 @@
+output "doi_database_subnets" {
+  value       = module.doi-vpc.database_subnet_group
+  description = "Private subnet of the DOI Server"
+}
+
 output "doi_server_subnets" {
   value       = module.doi-vpc.private_subnets
   description = "Private subnet of the DOI Server"


### PR DESCRIPTION
- Read the correct tf backend
- connect resources to the correct subnets

We can only assign an ec2 instance to one subnet, but we have 3 established in the vpc. will probably only want one network for private/public, but the database can be distributed across 3 subnets/azs