### PR TITLE
add backup plan

### DIFF
--- a/infrastructure/backup/backend.tf
+++ b/infrastructure/backup/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket = "doi-terraform-state-backend"
+    key    = "doi/backup/terraform.tfstate"
+    region = "eu-west-2"
+
+    dynamodb_table = "terraform_state"
+    encrypt        = true
+  }
+}

--- a/infrastructure/backup/main.tf
+++ b/infrastructure/backup/main.tf
@@ -1,0 +1,40 @@
+provider "aws" {
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      Environment = "DOI"
+      Owner       = "DiSSCo"
+      Project     = "DiSSCo DOI"
+      Terraform   = "True"
+    }
+  }
+}
+
+data "terraform_remote_state" "db-state" {
+  backend = "s3"
+
+  config = {
+    bucket = "doi-terraform-state-backend"
+    key    = "doi/database/terraform.tfstate"
+    region = "eu-west-2"
+  }
+}
+
+module "s3-bucket" {
+  bucket = "dissco-doi-backup"
+  source = "terraform-aws-modules/s3-bucket/aws"
+}
+
+module "rds-export-to-s3" {
+  source  = "binbashar/rds-export-to-s3/aws"
+
+  create_customer_kms_key = false
+  customer_kms_key_arn    = "arn:aws:secretsmanager:eu-west-2:824841205322:secret:rds!db-c0b80aa4-d161-4ccc-8a87-06e06568dbd2-rKvFrF"
+  database_names          = data.terraform_remote_state.db-state.outputs.db_name
+  prefix                  = "doi-snapshot"
+  snapshots_bucket_name   = module.s3-bucket.s3_bucket_id
+  snapshots_bucket_prefix = "backup/2023/"
+  rds_event_ids           = "RDS: RDS-EVENT-0091"
+}
+
+

--- a/infrastructure/database/outputs.tf
+++ b/infrastructure/database/outputs.tf
@@ -1,0 +1,4 @@
+output "db_name" {
+  value = aws_db_instance.default.db_name
+  description = "Name of the DOI Databse"
+}


### PR DESCRIPTION
Using [this module](https://github.com/binbashar/terraform-aws-rds-export-to-s3) to 
1. create cloudwatch monitoring for db snapshots 
2. create lambda function to push snapshots to s3 container which is triggered by that event

Unfortunately their lambda module is somewhat out of date but I added a github issue for it. Seems moderately active still so let's see what happens. 